### PR TITLE
Add external collision protection enabled srv

### DIFF
--- a/msg/ExternalCollisionProtectionNameList.msg
+++ b/msg/ExternalCollisionProtectionNameList.msg
@@ -1,0 +1,9 @@
+# A message for setExternalCollisionProtectionEnabled in External-Collision avoidance API
+
+uint8 number
+
+uint8 ALL=0
+uint8 MOVE=1
+uint8 ARMS=2
+uint8 LARM=3
+uint8 RARM=4

--- a/msg/ExternalCollisionProtectionNames.msg
+++ b/msg/ExternalCollisionProtectionNames.msg
@@ -1,6 +1,6 @@
 # A message for setExternalCollisionProtectionEnabled in External-Collision avoidance API
 
-uint8 number
+uint8 data
 
 uint8 ALL=0
 uint8 MOVE=1

--- a/srv/GetExternalCollisionProtectionEnabled.srv
+++ b/srv/GetExternalCollisionProtectionEnabled.srv
@@ -1,3 +1,4 @@
 # Get information about External Collision Protection Enabled
 naoqi_bridge_msgs/ExternalCollisionProtectionNames name
 ---
+bool status

--- a/srv/GetExternalCollisionProtectionEnabled.srv
+++ b/srv/GetExternalCollisionProtectionEnabled.srv
@@ -1,0 +1,3 @@
+# Get information about External Collision Protection Enabled
+std_msgs/String name
+---

--- a/srv/GetExternalCollisionProtectionEnabled.srv
+++ b/srv/GetExternalCollisionProtectionEnabled.srv
@@ -1,3 +1,3 @@
 # Get information about External Collision Protection Enabled
-std_msgs/String name
+naoqi_bridge_msgs/ExternalCollisionProtectionNameList name
 ---

--- a/srv/GetExternalCollisionProtectionEnabled.srv
+++ b/srv/GetExternalCollisionProtectionEnabled.srv
@@ -1,3 +1,3 @@
 # Get information about External Collision Protection Enabled
-naoqi_bridge_msgs/ExternalCollisionProtectionNameList name
+naoqi_bridge_msgs/ExternalCollisionProtectionNames name
 ---

--- a/srv/SetExternalCollisionProtectionEnabled.srv
+++ b/srv/SetExternalCollisionProtectionEnabled.srv
@@ -1,5 +1,5 @@
 # Set information about External Collision Protection Enabled
 naoqi_bridge_msgs/ExternalCollisionProtectionNames name
-bool status
+bool success
 ---
-bool status
+bool success

--- a/srv/SetExternalCollisionProtectionEnabled.srv
+++ b/srv/SetExternalCollisionProtectionEnabled.srv
@@ -1,0 +1,4 @@
+# Set information about External Collision Protection Enabled
+std_msgs/String name
+bool status
+---

--- a/srv/SetExternalCollisionProtectionEnabled.srv
+++ b/srv/SetExternalCollisionProtectionEnabled.srv
@@ -2,3 +2,4 @@
 naoqi_bridge_msgs/ExternalCollisionProtectionNames name
 bool status
 ---
+bool status

--- a/srv/SetExternalCollisionProtectionEnabled.srv
+++ b/srv/SetExternalCollisionProtectionEnabled.srv
@@ -1,5 +1,5 @@
 # Set information about External Collision Protection Enabled
 naoqi_bridge_msgs/ExternalCollisionProtectionNames name
-bool success
+bool status
 ---
 bool success

--- a/srv/SetExternalCollisionProtectionEnabled.srv
+++ b/srv/SetExternalCollisionProtectionEnabled.srv
@@ -1,4 +1,4 @@
 # Set information about External Collision Protection Enabled
-std_msgs/String name
+naoqi_bridge_msgs/ExternalCollisionProtectionNameList name
 bool status
 ---

--- a/srv/SetExternalCollisionProtectionEnabled.srv
+++ b/srv/SetExternalCollisionProtectionEnabled.srv
@@ -1,4 +1,4 @@
 # Set information about External Collision Protection Enabled
-naoqi_bridge_msgs/ExternalCollisionProtectionNameList name
+naoqi_bridge_msgs/ExternalCollisionProtectionNames name
 bool status
 ---


### PR DESCRIPTION
These two srv files are used to execute set / getExternalCollisionProtectionEnabled by using service.
1. GetExternalCollisionProtectionEnabled.srv :
   We set 
   `std_msgs/String name` : `“All”, “Move”, “Arms”, “LArm” or “RArm”`
2. SetExternalCollisionProtectionEnabled.srv:
   We set
   `std_msgs/String name` : `“All”, “Move”, “Arms”, “LArm” or “RArm”`
   `bool status` : `True or False` (which means enabled or disabled)                     

Links of two functions are here:
[getExternalCollisionPretectionEnabled](http://doc.aldebaran.com/2-1/naoqi/motion/reflexes-external-collision-api.html?highlight=getexternalcollision#ALMotionProxy::getExternalCollisionProtectionEnabled__ssCR)
[setExternalCollisionProtectionEnabled](http://doc.aldebaran.com/2-1/naoqi/motion/reflexes-external-collision-api.html?highlight=setexternalcollision#ALMotionProxy::setExternalCollisionProtectionEnabled__ssCR.bCR)

If there is any problem, please let me know.
