### PR TITLE
add ALPhotoCapture related srv/msg files

### DIFF
--- a/msg/PhotoCaptureResolutionTypes.msg
+++ b/msg/PhotoCaptureResolutionTypes.msg
@@ -1,0 +1,5 @@
+uint8 data
+
+uint8 KQQVGA=0
+uint8 KQVGA=1
+uint8 KVGA=2

--- a/msg/PictureFormatNames.msg
+++ b/msg/PictureFormatNames.msg
@@ -1,0 +1,15 @@
+uint8 data
+
+uint8 BMP=0
+uint8 DIB=1
+uint8 JPEG=2
+uint8 JPG=3
+uint8 JPE=4
+uint8 PNG=5
+uint8 PBM=6
+uint8 PGM=7
+uint8 PPM=8
+uint8 SR=9
+uint8 RAS=10
+uint8 TIFF=11
+uint8 TIF=12

--- a/srv/GetFolderPath.srv
+++ b/srv/GetFolderPath.srv
@@ -1,0 +1,2 @@
+---
+std_msgs/String folder_path

--- a/srv/GetPictureFormat.srv
+++ b/srv/GetPictureFormat.srv
@@ -1,0 +1,2 @@
+---
+naoqi_bridge_msgs/PictureFormatNames name

--- a/srv/PhotoCaptureGetResolution.srv
+++ b/srv/PhotoCaptureGetResolution.srv
@@ -1,0 +1,2 @@
+---
+naoqi_bridge_msgs/PhotoCaptureResolutionTypes name

--- a/srv/PhotoCaptureSetResolution.srv
+++ b/srv/PhotoCaptureSetResolution.srv
@@ -1,0 +1,2 @@
+naoqi_bridge_msgs/PhotoCaptureResolutionTypes name
+---

--- a/srv/SetFolderPath.srv
+++ b/srv/SetFolderPath.srv
@@ -1,0 +1,2 @@
+std_msgs/String folder_path
+---

--- a/srv/SetPictureFormat.srv
+++ b/srv/SetPictureFormat.srv
@@ -1,0 +1,2 @@
+naoqi_bridge_msgs/PictureFormatNames name
+---

--- a/srv/TakePicture.srv
+++ b/srv/TakePicture.srv
@@ -1,0 +1,3 @@
+std_msgs/String picture_name
+---
+std_msgs/Bool status


### PR DESCRIPTION
I added seven srv files and two msg files for `ALPhotoCapture` (functions related to `takePicture`).

PhotoCaptureSetResolution.srv, which includes PhotoCaptureResolutionTypes.msg : `setResolution`
PhotoCaptureGetResolution.srv, which includes PhotoCaptureResolutionTypes.msg : `getResolution`
SetPictureFormat.srv, which includes PictureFormatNames.msg : `setPictureFormat`
GetPictureFromat.srv, which includes PictureFormatNames.msg : `getPictureFormat`
TakePicture.srv : `takePicture`
SetFolderPath.srv : This determines the folder path, which is used for `takePicture(<folder path>, <file name>)`.
GetFolderPath.srv : This returns the folder path.

My concern is that `ALVideoRecorderProxy` also has `set/getResolution`, and its parameter `resolution` (0~8) is a little different from that of `ALPhotoCapture` (0~2). 
 That is why I added PhotoCapture to PhotoCaptureResolutionTypes.msg, PhotoCaptureSetResolution.srv, PhotoCaptureGetResolution.msg. 

If there is any problem, please let me know.
