### PR TITLE
[ALMotion/ external-collision avoidance] rename OrthogonalSecurityDistance TangentialSecurityDistance

### DIFF
--- a/srv/GetOrthogonalSecurityDistance.srv
+++ b/srv/GetOrthogonalSecurityDistance.srv
@@ -1,0 +1,5 @@
+# Service for getting the orthogonal security distance
+
+# Empty response
+---
+float32 orthogonal_distance

--- a/srv/GetTangentialSecurityDistance.srv
+++ b/srv/GetTangentialSecurityDistance.srv
@@ -1,0 +1,5 @@
+# Service for getting the tangential security distance
+
+# Empty response
+---
+float32 tangential_distance

--- a/srv/OrthogonalSecurityDistance.srv
+++ b/srv/OrthogonalSecurityDistance.srv
@@ -1,5 +1,0 @@
-# Service for setting the orthogonal security distance of Pepper
-
-std_msgs/Float32 orthogonal_distance
----
-# Empty response

--- a/srv/SetOrthogonalSecurityDistance.srv
+++ b/srv/SetOrthogonalSecurityDistance.srv
@@ -1,0 +1,5 @@
+# Service for setting the orthogonal security distance
+
+float32 orthogonal_distance
+---
+bool success

--- a/srv/SetTangentialSecurityDistance.srv
+++ b/srv/SetTangentialSecurityDistance.srv
@@ -1,0 +1,5 @@
+# Service for setting the tangential security distance
+
+float32 tangential_distance
+---
+bool success

--- a/srv/TangentialSecurityDistance.srv
+++ b/srv/TangentialSecurityDistance.srv
@@ -1,5 +1,0 @@
-# Service for setting the tangential security distance of Pepper
-
-std_msgs/Float32 tangential_distance
----
-# Empty response


### PR DESCRIPTION
I renamed `OrthogonalSecurityDistance.srv` and `TangentialSecurityDistance.srv` to `SetOrthogonalSecurityDistance.srv`, `GetOrthogonalSecurityDistance.srv`, `SetTangentialSecurityDistance.srv` and `GetTangentialSecurityDistance.srv`.
