### PR TITLE
[ALMotion/ external-collision avoidance] add ChainClosestObstaclePosition.msg

### DIFF
--- a/msg/ChainClosestObstaclePosition.msg
+++ b/msg/ChainClosestObstaclePosition.msg
@@ -1,0 +1,3 @@
+Header header
+string chain
+geometry_msgs/Vector3 obstacle_position


### PR DESCRIPTION
This is a message for `Event: "ALMotion/Safety/ChainVelocityClipped"` in external-collision avoidance APIs of ALMotion.
