### PR TITLE
[ALMotion/ external-collision avoidance] add GetChainClosestObstaclePosition.srv and Frames.msg

### DIFF
--- a/msg/Frames.msg
+++ b/msg/Frames.msg
@@ -1,0 +1,7 @@
+# A message for getChainClosestObstaclePosition in External-Collision avoidance API 
+
+uint8 data
+
+uint8 FRAME_TORSO=0
+uint8 FRAME_WORLD=1
+uint8 FRAME_ROBOT=2

--- a/srv/GetChainClosestObstaclePosition.srv
+++ b/srv/GetChainClosestObstaclePosition.srv
@@ -1,0 +1,5 @@
+# Get information about Chain Closest Obstacle Position
+naoqi_bridge_msgs/Arms arm
+naoqi_bridge_msgs/Frames frame
+---
+geometry_msgs/Vector3 obstacle_position


### PR DESCRIPTION
These are two message files and service file for `ALMotionProxy::getChainClosestObstaclePosition` in external-collision avoidance APIs of ALMotion.
