### PR TITLE
[ALMotion/locomotion control] add GetArmsEnabled.srv

### DIFF
--- a/srv/GetArmsEnabled.srv
+++ b/srv/GetArmsEnabled.srv
@@ -1,0 +1,3 @@
+naoqi_bridge_msgs/Arms arm
+---
+bool status


### PR DESCRIPTION
This is a service file for `getMoveArmsEnabled` in `ALMotion/locomotion control`.
I followed the `SetArmsEnabled` for the file name.
