### PR TITLE
[wip] add srv and msg for naoqi_apps/launch/speech_recognition.launch

### DIFF
--- a/msg/WordRecognizedAndGrammar.msg
+++ b/msg/WordRecognizedAndGrammar.msg
@@ -1,0 +1,5 @@
+# It contains the list of words recognized, confidence values and grammar names
+# Both arrays are of the same length
+string[] words
+float32[] confidence_values
+string[] grammars

--- a/srv/ActivateAllRules.srv
+++ b/srv/ActivateAllRules.srv
@@ -1,0 +1,5 @@
+# Activates all rules contained in the specified context
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+string contextName
+---
+bool success

--- a/srv/ActivateRule.srv
+++ b/srv/ActivateRule.srv
@@ -1,0 +1,6 @@
+# Activates a rule contained in the specified context
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+string contextName
+string ruleName
+---
+bool success

--- a/srv/AddContext.srv
+++ b/srv/AddContext.srv
@@ -1,0 +1,6 @@
+# Adds the context contained in the LCF file
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+string pathToOutputLCFFile
+string contextName
+---
+bool success

--- a/srv/AddWordListToSlot.srv
+++ b/srv/AddWordListToSlot.srv
@@ -1,0 +1,7 @@
+# Adds a list of words in a slot
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+string contextName 
+string slotName
+string[] wordList
+---
+bool success

--- a/srv/CompileBNFToLCF.srv
+++ b/srv/CompileBNFToLCF.srv
@@ -1,0 +1,7 @@
+# Converts a BNF file to a LCF file
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+string pathToInputBNFFile 
+string pathToOutputLCFFile
+string language
+---
+bool success

--- a/srv/DeactivateAllRules.srv
+++ b/srv/DeactivateAllRules.srv
@@ -1,0 +1,5 @@
+# Deactivates all rules contained in the specified context
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+string contextName
+---
+bool success

--- a/srv/DeactivateRule.srv
+++ b/srv/DeactivateRule.srv
@@ -1,0 +1,6 @@
+# Deactivates a rule contained in the specified context
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+string contextName
+string ruleName
+---
+bool success

--- a/srv/EraseContextSet.srv
+++ b/srv/EraseContextSet.srv
@@ -1,0 +1,5 @@
+# Erases the save named saveName
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+string saveName
+---
+bool success

--- a/srv/GetAudioExpression.srv
+++ b/srv/GetAudioExpression.srv
@@ -1,0 +1,4 @@
+# Gets value of the parameter AudioExpression
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+---
+bool setOrNot

--- a/srv/GetAvailableLanguages.srv
+++ b/srv/GetAvailableLanguages.srv
@@ -1,0 +1,4 @@
+# Returns the list of the languages currently installed on the system
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+---
+string[] languages

--- a/srv/GetLanguage.srv
+++ b/srv/GetLanguage.srv
@@ -1,0 +1,4 @@
+# Returns the list of the language currently used by the speech recognition system
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+---
+string language

--- a/srv/GetRules.srv
+++ b/srv/GetRules.srv
@@ -1,0 +1,7 @@
+# Gets rules corresponding to the specified type
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+string contextName 
+string typeName
+# type: "start" "active" "activatable" "slot"
+---
+string[] rules

--- a/srv/GetSpeechRecognitionParameter.srv
+++ b/srv/GetSpeechRecognitionParameter.srv
@@ -1,0 +1,6 @@
+# Gets a parameter of the speech recognition engine
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+string parameter
+# Sensitivity is available
+---
+float64 value

--- a/srv/LoadContextSet.srv
+++ b/srv/LoadContextSet.srv
@@ -1,0 +1,5 @@
+# Replaces the currently loaded context set by the one previously saved under the name saveName
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+string saveName
+---
+bool success

--- a/srv/Pause.srv
+++ b/srv/Pause.srv
@@ -1,0 +1,5 @@
+# Stops and restarts the speech recognition engine according to the input parameter
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+bool isPaused
+---
+bool success

--- a/srv/RemoveContext.srv
+++ b/srv/RemoveContext.srv
@@ -1,0 +1,5 @@
+# Removes one context from the speech recognition engine
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+string contextName
+---
+bool success

--- a/srv/RemoveWordListFromSlot.srv
+++ b/srv/RemoveWordListFromSlot.srv
@@ -1,0 +1,6 @@
+# Removes all words from a slot
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+string contextName 
+string slotName
+---
+bool success

--- a/srv/SaveContextSet.srv
+++ b/srv/SaveContextSet.srv
@@ -1,0 +1,5 @@
+# Saves the current context set under the name saveName 
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+string saveName
+---
+bool success

--- a/srv/SetAudioExpression.srv
+++ b/srv/SetAudioExpression.srv
@@ -1,0 +1,5 @@
+# Sets "bip" on the speech recognition engine
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+bool setOrNot
+---
+bool success

--- a/srv/SetLanguage.srv
+++ b/srv/SetLanguage.srv
@@ -1,0 +1,5 @@
+# Sets the language currently used by the speech recognition system
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+string language
+---
+bool success

--- a/srv/SetSpeechRecognitionParameter.srv
+++ b/srv/SetSpeechRecognitionParameter.srv
@@ -1,0 +1,7 @@
+# Sets a parameter of the speech recognition engine
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+string parameter
+# Sensitivity, NbHypothesis are available
+float64 value
+---
+bool success

--- a/srv/SetVisualExpression.srv
+++ b/srv/SetVisualExpression.srv
@@ -1,0 +1,5 @@
+# Enables or disables the leds animations on the speech recognition engine
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+bool setOrNot
+---
+bool success

--- a/srv/SetVocabulary.srv
+++ b/srv/SetVocabulary.srv
@@ -1,0 +1,6 @@
+# Sets the list of words/phrases (vocabulary) that should be recognized by the speech recognition engine
+# please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api
+string[] vocabulary
+bool enableWordSpotting
+---
+bool success


### PR DESCRIPTION
These are srvs and msg for ALSpeechRecognition (http://doc.aldebaran.com/2-4/naoqi/audio/alspeechrecognition-api.html#alspeechrecognition-api) .

related to: 

If there is any problem, please let me know.
-    WordRecognizedAndGrammar.msg
  used for `WordRecognizedAndGrammar()`
-    ActivateAllRules.srv
  used for `activateAllRules`
- ActivateRule.srv
  used for `activateRule`
-    AddContext.srv 
  used for `addContext`
-    AddWordListToSlot.srv
  used for `addWordListToSlot`
-    CompileBNFToLCF.srv
  used for `compile`
-    DeactivateAllRules.srv
  used for `deactivateAllRules`
-    DeactivateRule.srv
  used for `deactivateRule`
-    EraseContextSet.srv
  used for `eraseContextSet`
-    GetAudioExpression.srv
  used for `getAudioExpression`
-    GetAvailableLanguages.srv
  used for `getAvailableLanguages`
-    GetLanguage.srv
  used for `getLanguage`
-    GetRules.srv
  used for `getRules`
-    GetSpeechRecognitionParameter.srv
  used for `getParameter`
-    LoadContextSet.srv
  used for `loadContextSet`
-    Pause.srv
  used for `pause`
-   RemoveContext.srv
  used for `removeContext`
-    RemoveWordListFromSlot.srv
  used for `removeWordListFromSlot`
-    SaveContextSet.srv
  used for `saveContextSet`
-    SetAudioExpression.srv
  used for `setAudioExpression`
-    SetLanguage.srv
  used for `setLanguage`
-    SetSpeechRecognitionParameter.srv
  used for `setParameter`
-    SetVisualExpression.srv
  used for `setVIsualExpression`
-    SetVocabulary.srv
  used for `setVocabulary`
