### PR TITLE
add srv and msg for naoqi_apps/launch/gaze_analysis.launch

### DIFF
--- a/msg/GazeAnalysis.msg
+++ b/msg/GazeAnalysis.msg
@@ -1,0 +1,9 @@
+Header header
+uint64 people_id
+float64 left_eye_opening_degree
+float64 right_eye_opening_degree
+float64 gaze_direction_yaw
+float64 gaze_direction_pitch
+geometry_msgs/Vector3 head_angles
+bool is_looking_at_robot
+float64 looking_at_robot_score

--- a/srv/GetGazeAnalysisTolerance.srv
+++ b/srv/GetGazeAnalysisTolerance.srv
@@ -1,0 +1,4 @@
+# Gets the value of the Tolerance for gaze analysis
+# Please refer to http://doc.aldebaran.com/2-4/naoqi/peopleperception/algazeanalysis-api.html#algazeanalysis-api
+---
+float64 tolerance

--- a/srv/SetGazeAnalysisTolerance.srv
+++ b/srv/SetGazeAnalysisTolerance.srv
@@ -1,0 +1,5 @@
+# Sets the value of the Tolerance for gaze analysis
+# Please refer to http://doc.aldebaran.com/2-4/naoqi/peopleperception/algazeanalysis-api.html#algazeanalysis-api
+float64 tolerance 
+---
+bool success


### PR DESCRIPTION
These are srvs and msg for ALGazeAnalysis (http://doc.aldebaran.com/2-4/naoqi/peopleperception/algazeanalysis-api.html#algazeanalysis-api)

If there is any problem, please let me know.
- GazeAnalysis.msg
  is used for five memory keys

```
PeoplePerception/Person/<ID>/EyeOpeningDegree
PeoplePerception/Person/<ID>/GazeDirection
PeoplePerception/Person/<ID>/HeadAngles
PeoplePerception/Person/<ID>/IsLookingAtRobot
PeoplePerception/Person/<ID>/LookingAtRobotScore
```
- GetGazeAnalysisTolerance.srv 
  is used for one method
  `ALGazeAnalysisProxy::getTolerance()`
- SetGazeAnalysisTolerance.srv 
  is used for one method
  `ALGazeAnalysisProxy::setTolerance()`
