### PR TITLE
add msgs and srvs for naoqi_apps/launch/face_detection.launch

### DIFF
--- a/msg/EyePoints.msg
+++ b/msg/EyePoints.msg
@@ -1,0 +1,6 @@
+float64 eye_center_x
+float64 eye_center_y
+float64 nose_side_limit_x
+float64 nose_side_limit_y
+float64 ear_side_limit_x
+float64 ear_side_limit_y

--- a/msg/FaceDetected.msg
+++ b/msg/FaceDetected.msg
@@ -1,0 +1,6 @@
+Header header
+naoqi_bridge_msgs/FaceInfo face_info
+naoqi_bridge_msgs/TimeFilteredRecoInfo time_filtered_reco_info
+geometry_msgs/Twist camera_pose_in_torso_frame
+geometry_msgs/Twist camera_pose_in_robot_frame
+uint8 camera_id

--- a/msg/FaceDetectionExtraInfo.msg
+++ b/msg/FaceDetectionExtraInfo.msg
@@ -1,0 +1,7 @@
+int64 face_id
+float64 recognition_score
+string face_label
+naoqi_bridge_msgs/EyePoints left_eye
+naoqi_bridge_msgs/EyePoints right_eye
+naoqi_bridge_msgs/NosePoints nose
+naoqi_bridge_msgs/MouthPoints mouth

--- a/msg/FaceDetectionShapeInfo.msg
+++ b/msg/FaceDetectionShapeInfo.msg
@@ -1,0 +1,4 @@
+float64 alpha
+float64 beta
+float64 size_x
+float64 size_y

--- a/msg/FaceInfo.msg
+++ b/msg/FaceInfo.msg
@@ -1,0 +1,2 @@
+naoqi_bridge_msgs/FaceDetectionShapeInfo shape_info
+naoqi_bridge_msgs/FaceDetectionExtraInfo extra_info

--- a/msg/MouthPoints.msg
+++ b/msg/MouthPoints.msg
@@ -1,0 +1,6 @@
+float64 left_limit_x
+float64 left_limit_y
+float64 right_limit_x
+float64 right_limit_y
+float64 top_limit_x
+float64 top_limit_y

--- a/msg/NosePoints.msg
+++ b/msg/NosePoints.msg
@@ -1,0 +1,6 @@
+float64 bottom_center_limit_x
+float64 bottom_center_limit_y
+float64 bottom_left_limit_x
+float64 bottom_left_limit_y
+float64 bottom_right_limit_x
+float64 bottom_right_limit_y

--- a/msg/TimeFilteredRecoInfo.msg
+++ b/msg/TimeFilteredRecoInfo.msg
@@ -1,0 +1,3 @@
+uint8 status 
+# 2: there is one face recognized 3: there are several recognized faces 4: a face has been detected for more than 8 seconds without being recognized
+string[] face_label

--- a/srv/ClearDatabase.srv
+++ b/srv/ClearDatabase.srv
@@ -1,0 +1,4 @@
+# Removes all learned faces from the database.
+# Please refer to http://doc.aldebaran.com/2-4/naoqi/peopleperception/alfacedetection-api.html#alfacedetection-api
+---
+bool success

--- a/srv/ForgetPerson.srv
+++ b/srv/ForgetPerson.srv
@@ -1,0 +1,5 @@
+# Deletes from the database all learned faces corresponding to the specified person.
+# Please refer to http://doc.aldebaran.com/2-4/naoqi/peopleperception/alfacedetection-api.html#alfacedetection-api
+string name
+---
+bool success

--- a/srv/GetLearnedFacesList.srv
+++ b/srv/GetLearnedFacesList.srv
@@ -1,0 +1,4 @@
+# Gets a list containing the name of each learned face. 
+# Please refer to http://doc.aldebaran.com/2-4/naoqi/peopleperception/alfacedetection-api.html#alfacedetection-api
+---
+string[] names

--- a/srv/GetRecognitionConfidenceThreshold.srv
+++ b/srv/GetRecognitionConfidenceThreshold.srv
@@ -1,0 +1,4 @@
+# Returns the current threshold value used for face recognition.
+# Please refer to http://doc.aldebaran.com/2-4/naoqi/peopleperception/alfacedetection-api.html#alfacedetection-api
+---
+float64 threshold

--- a/srv/IsRecognitionEnabled.srv
+++ b/srv/IsRecognitionEnabled.srv
@@ -1,0 +1,4 @@
+# Returns whether recognition is enabled. Recognition is enabled by default.
+# Please refer to http://doc.aldebaran.com/2-4/naoqi/peopleperception/alfacedetection-api.html#alfacedetection-api
+---
+bool status

--- a/srv/IsTrackingEnabled.srv
+++ b/srv/IsTrackingEnabled.srv
@@ -1,0 +1,4 @@
+# Returns whether tracking is enabled. Tracking is enabled by default.
+# Please refer to http://doc.aldebaran.com/2-4/naoqi/peopleperception/alfacedetection-api.html#alfacedetection-api
+---
+bool status

--- a/srv/LearnFace.srv
+++ b/srv/LearnFace.srv
@@ -1,0 +1,5 @@
+# Learns a new face and add it in the database under the specified name.
+# Please refer to http://doc.aldebaran.com/2-4/naoqi/peopleperception/alfacedetection-api.html#alfacedetection-api
+string name
+---
+bool success

--- a/srv/ReLearnFace.srv
+++ b/srv/ReLearnFace.srv
@@ -1,0 +1,5 @@
+# Uses, in a new learning process, the latest images where a face has been wrongly recognized.
+# Please refer to http://doc.aldebaran.com/2-4/naoqi/peopleperception/alfacedetection-api.html#alfacedetection-api
+string name
+---
+bool success

--- a/srv/SetRecognitionConfidenceThreshold.srv
+++ b/srv/SetRecognitionConfidenceThreshold.srv
@@ -1,0 +1,5 @@
+# Enables/disables the face recognition process.
+# Please refer to http://doc.aldebaran.com/2-4/naoqi/peopleperception/alfacedetection-api.html#alfacedetection-api
+float64 threshold
+---
+bool success

--- a/srv/SetRecognitionEnabled.srv
+++ b/srv/SetRecognitionEnabled.srv
@@ -1,0 +1,5 @@
+# Enables/disables the face recognition process. 
+# Please refer to http://doc.aldebaran.com/2-4/naoqi/peopleperception/alfacedetection-api.html#alfacedetection-api
+bool enable
+---
+bool success

--- a/srv/SetTrackingEnabled.srv
+++ b/srv/SetTrackingEnabled.srv
@@ -1,0 +1,5 @@
+# Enables/disables face tracking.
+# Please refer to http://doc.aldebaran.com/2-4/naoqi/peopleperception/alfacedetection-api.html#alfacedetection-api
+bool enable
+---
+bool success


### PR DESCRIPTION
I followed http://doc.aldebaran.com/2-4/naoqi/peopleperception/alfacedetection-api.html#alfacedetection-api
I'll write the explanation on this pull request. Sorry for my trouble. => EDITTED
- - - 
msg/FaceDetected.msg has

-    msg/FaceInfo.msg
-    msg/TimeFilteredRecoInfo.msg

msg/FaceInfo.msg
= msg/FaceDetectionExtraInfo.msg + msg/FaceDetectionShapeInfo.msg

msg/FaceDetectionExtraInfo.msg has
-    msg/EyePoints.msg
-    msg/MouthPoints.msg
-    msg/NosePoints.msg

I created msg files based on http://doc.aldebaran.com/2-4/naoqi/peopleperception/alfacedetection.html#alfacedetection
these msgs are used for 
- topic: /face_detected (FaceDetected())

```
rostopic echo /face_detected

---
header: 
  seq: 335
  stamp: 
    secs: 1477994512
    nsecs: 522608041
  frame_id: ''
face_info: 
  shape_info: 
    alpha: -0.0155988810584
    beta: 0.0483238063753
    size_x: 0.243342548609
    size_y: 0.251283794641
  extra_info: 
    face_id: 1
    recognition_score: 0.0
    face_label: ''
    left_eye: 
      eye_center_x: 0.499164193869
      eye_center_y: -0.386590451002
      nose_side_limit_x: 0.499164193869
      nose_side_limit_y: -0.386590451002
      ear_side_limit_x: 0.499164193869
      ear_side_limit_y: -0.386590451002
    right_eye: 
      eye_center_x: 0.499164193869
      eye_center_y: -0.386590451002
      nose_side_limit_x: 0.499164193869
      nose_side_limit_y: -0.386590451002
      ear_side_limit_x: 0.499164193869
      ear_side_limit_y: -0.386590451002
    nose: 
      bottom_center_limit_x: 0.499164193869
      bottom_center_limit_y: -0.386590451002
      bottom_left_limit_x: 0.499164193869
      bottom_left_limit_y: -0.386590451002
      bottom_right_limit_x: 0.499164193869
      bottom_right_limit_y: -0.386590451002
    mouth: 
      left_limit_x: 0.499164193869
      left_limit_y: -0.386590451002
      right_limit_x: 0.499164193869
      right_limit_y: -0.386590451002
      top_limit_x: 0.499164193869
      top_limit_y: -0.386590451002
time_filtered_reco_info: 
  status: 0
  face_label: []
camera_pose_in_torso_frame: 
  linear: 
    x: 0.042243603617
    y: 0.0330938622355
    z: 0.333000004292
  angular: 
    x: 0.0
    y: -0.0
    z: 0.391165047884
camera_pose_in_robot_frame: 
  linear: 
    x: 0.0721535384655
    y: 0.0309213902801
    z: 1.14981913567
  angular: 
    x: 0.025911744684
    y: 0.0507121346891
    z: 0.391691565514
camera_id: 0
```

services:
``` srv/ClearDatabase.srv ```
- /clear_database (bool ALFaceDetectionProxy::clearDatabase())

``` srv/ForgetPerson.srv ```
- /forget_person (bool ALFaceDetectionProxy::forgetPerson(const std::string& name))

``` srv/GetLearnedFacesList.srv ```
- /get_learned_facesList: (AL::ALValue ALFaceDetectionProxy::getLearnedFacesList())

``` srv/GetRecognitionConfidenceThreshold.srv ```
- /get_recognition_confidence_threshold (float ALFaceDetectionProxy::getRecognitionConfidenceThreshold())

``` srv/IsRecognitionEnabled.srv ```
- /is_recognition_enabled (bool ALFaceDetectionProxy::isRecognitionEnabled())

``` srv/IsTrackingEnabled.srv ```
/is_tracking_enabled (bool ALFaceDetectionProxy::isTrackingEnabled())

``` srv/LearnFace.srv ```
/learn_face (bool ALFaceDetectionProxy::learnFace(const std::string& name))

``` srv/ReLearnFace.srv ```
/relearn_face (bool ALFaceDetectionProxy::reLearnFace(const std::string& name))

``` srv/SetRecognitionConfidenceThreshold.srv ```
/set_recognition_confidence_threshold (void ALFaceDetectionProxy::setRecognitionConfidenceThreshold(float threshold))

``` srv/SetRecognitionEnabled.srv ```
/set_recognition_enabled (void ALFaceDetectionProxy::setRecognitionEnabled(const bool& enable))

``` srv/SetTrackingEnabled.srv ```
/set_tracking_enabled (void ALFaceDetectionProxy::setTrackingEnabled(const bool& enable))