### PR TITLE
[SetEnergyComputaion.srv] delete msg because it can be replaced by std_srvs/SetBool.srv

### DIFF
--- a/srv/SetEnergyComputation.srv
+++ b/srv/SetEnergyComputation.srv
@@ -1,5 +1,0 @@
-# Set EnergyComputation parameter for ALSoundLocalization
-# Please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alsoundlocalization-api.html#alsoundlocalization-api 
-bool status
----
-bool success


### PR DESCRIPTION
- delete `SetEnergyComputation.srv` because it can be replaced by `std_srvs/srv/SetBool.srv`
ref: https://github.com/ros-naoqi/naoqi_bridge_msgs/pull/21

Sorry for my trouble.