### PR TITLE
[SetSensitivity.srv] delete srv file because it can be replaced by #37

### DIFF
--- a/srv/SetSensitivity.srv
+++ b/srv/SetSensitivity.srv
@@ -1,4 +1,0 @@
-# Set Sensitivity parameter for ALSoundLocalization                                                                  # Please refer to http://doc.aldebaran.com/2-4/naoqi/audio/alsoundlocalization-api.html#alsoundlocalization-api            
-float64 sensitivity # 0.0 - 1.0
----
-bool success


### PR DESCRIPTION
- delete `SetSensitivity.srv` because it can be replaced by #37.
ref: https://github.com/ros-naoqi/naoqi_bridge_msgs/pull/21

Sorry for my trouble.