### PR TITLE
add fade leds srv

### DIFF
--- a/srv/FadeLeds.srv
+++ b/srv/FadeLeds.srv
@@ -1,0 +1,2 @@
+naoqi_bridge_msgs/FadeRGB fade_rgb
+---


### PR DESCRIPTION
I added FadeLeds.srv to use `fadeRGB` as a service.
ref: http://doc.aldebaran.com/2-5/naoqi/sensors/alleds-api.html#ALLedsProxy::fadeRGB__ssCR.floatCR.floatCR.floatCR.floatCR

related pull-request: https://github.com/ros-naoqi/naoqi_driver/pull/100
