### PR TITLE
PoseStampedWithSpeed message for base motion

### DIFF
--- a/msg/PoseStampedWithSpeed.msg
+++ b/msg/PoseStampedWithSpeed.msg
@@ -1,0 +1,13 @@
+# Header of the message
+std_msgs/Header header
+
+# The reference frame for the movement
+# 1: FRAME_WORLD
+# 2: FRAME_ROBOT
+int32 reference_frame
+
+# The pose stamped
+geometry_msgs/PoseStamped pose_stamped
+
+# The speed percentage of the movement
+float64 speed_percentage

--- a/msg/PoseStampedWithSpeed.msg
+++ b/msg/PoseStampedWithSpeed.msg
@@ -1,11 +1,3 @@
-# Header of the message
-std_msgs/Header header
-
-# The reference frame for the movement
-# 1: FRAME_WORLD
-# 2: FRAME_ROBOT
-int32 reference_frame
-
 # The pose stamped
 geometry_msgs/PoseStamped pose_stamped
 


### PR DESCRIPTION
The structure of the message is the following:
* __header:__ The header of the message _(std_msgs/Header)_
* __reference_frame:__ The reference frame for the movement, 1 is the odom frame and 2 the robot frame (as defined in the naoqi framework) _(int32)_
* __pose_stamped:__ The position to be reached _(geometry_msgs/PoseStamped)_
* __speed_percentage:__ The speed of the movement, percentage of the maximum reachable speed by the robot's base _(float64)_

This PR is linked to that [PR](https://github.com/ros-naoqi/naoqi_driver/pull/116) in __naoqi_driver__.